### PR TITLE
Check for file redirection on POSIX platforms

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
   -cppcoreguidelines-pro-type-vararg,
   -hicpp-vararg,
   -readability-convert-member-functions-to-static,
+  -cppcoreguidelines-macro-usage
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'src/.*'
 AnalyzeTemporaryDtors: false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES
   "platform.cpp"
   "platform-factory.h"
   "platform-factory.cpp"
+  "platform-posix.h"
+  "platform-posix.cpp"
   "platform-windows.h"
   "platform-windows.cpp"
 )

--- a/src/platform-factory.cpp
+++ b/src/platform-factory.cpp
@@ -1,5 +1,6 @@
 #include "platform-factory.h"
 
+#include "platform-posix.h"
 #include "platform-windows.h"
 
 namespace fun
@@ -8,6 +9,8 @@ const Platform* PlatformFactory::Current()
 {
 #if TARGET_WINDOWS
   return new PlatformWindows();
+#elif TARGET_POSIX
+  return new PlatformPosix();
 #else
   return new Platform();
 #endif

--- a/src/platform-posix.cpp
+++ b/src/platform-posix.cpp
@@ -1,0 +1,25 @@
+#include "platform.h"
+
+#if TARGET_POSIX
+
+#include "platform-posix.h"
+
+#include <cstdio>
+#include <unistd.h>
+
+namespace fun
+{
+static bool supportsControlCharacters = true;
+
+PlatformPosix::PlatformPosix()
+{
+  supportsControlCharacters = isatty(STDOUT_FILENO) == 1;
+}
+
+bool PlatformPosix::SupportsControlCharacters() const
+{
+  return supportsControlCharacters;
+}
+} // namespace fun
+
+#endif // TARGET_POSIX

--- a/src/platform-posix.h
+++ b/src/platform-posix.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "platform.h"
+
+namespace fun
+{
+class PlatformPosix : public Platform
+{
+public:
+  PlatformPosix();
+  bool SupportsControlCharacters() const override;
+};
+} // namespace fun

--- a/src/platform.h
+++ b/src/platform.h
@@ -2,6 +2,8 @@
 
 #if defined(_WIN32) || defined(WIN32)
 #define TARGET_WINDOWS 1
+#else
+#define TARGET_POSIX 1
 #endif
 
 namespace fun


### PR DESCRIPTION
* Add the concept of POSIX platforms
* Use `isatty` to check for file redirection
* If stdout is redirected, don't print control characters
* Ignore a clang-tidy check that prevents macros
